### PR TITLE
Fix wrongly marking my emulator as having pirate apps installed

### DIFF
--- a/app/src/main/java/com/andreacioccarelli/billingprotectorsample/MainActivity.kt
+++ b/app/src/main/java/com/andreacioccarelli/billingprotectorsample/MainActivity.kt
@@ -23,10 +23,10 @@ class MainActivity : AppCompatActivity() {
         val bp = BillingProtector(baseContext)
 
         val isRootDetected = bp.isRootInstalled()
-        val arePirateAppsInstalled = bp.getPirateAppsList()
+        val arePirateAppsInstalled = bp.arePirateAppsInstalled()
         val pirateList = bp.getPirateAppsList()
 
-        mxp.text = "isRootInstalled: $isRootDetected\narePirateAppsInstalled: $arePirateAppsInstalled\npirateAppsList: ${pirateList.map { it.packageName }}"
+        mxp.text = "isRootInstalled: $isRootDetected\narePirateAppsInstalled: $arePirateAppsInstalled\n\npirateAppsList: ${pirateList.map { it.packageName }}"
 
         fab.setOnClickListener {
             startActivity(Intent(this, SecondaryActivity::class.java))

--- a/app/src/main/java/com/andreacioccarelli/billingprotectorsample/SecondaryActivity.java
+++ b/app/src/main/java/com/andreacioccarelli/billingprotectorsample/SecondaryActivity.java
@@ -27,16 +27,15 @@ public class SecondaryActivity extends Activity {
         TextView mxp = findViewById(R.id.mxp);
         mxp.setText(
                 "isRootInstalled: " + String.valueOf(bp.isRootInstalled()) +
-                        "\narePirateAppsInstalled: " + bp.getPirateAppsList() +
-                        "\npirateAppsList: " + bp.getPirateAppsList()
+                        "\narePirateAppsInstalled: " + bp.arePirateAppsInstalled() +
+                        "\n\npirateAppsList: " + bp.getPirateAppsList()
         );
 
         FloatingActionButton fab = findViewById(R.id.fab);
         fab.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                Intent X = new Intent(getApplicationContext(), MainActivity.class);
-                startActivity(X);
+                finish();
             }
         });
     }

--- a/library/src/main/java/com/andreacioccarelli/billingprotector/BillingProtector.kt
+++ b/library/src/main/java/com/andreacioccarelli/billingprotector/BillingProtector.kt
@@ -22,23 +22,24 @@ class BillingProtector(private val context: Context) {
     /**
      * Returns a String, representing the root binary path, if present.
      * */
-    fun getRootBinatyPath() = RootUtils.extractPath()
+    fun getRootBinaryPath() = RootUtils.extractPath()
 
     /**
      * Returns a boolean that indicates the presence of pirate apps in the host system
      * */
     fun arePirateAppsInstalled(): Boolean {
-        val appList = context.packageManager.getInstalledApplications(PackageManager.GET_META_DATA)
+        val installedApps = context.packageManager.getInstalledApplications(PackageManager.GET_META_DATA)
+        val pirateApps = createPirateAppsList()
 
-        for (app in appList) {
-            createPirateAppsList().map {
+        installedApps.forEach { installedApp ->
+            pirateApps.forEach {
                 when (it.criteria) {
                     SelectionCriteria.SLICE -> {
-                        if (it.packageName.contains(app.packageName)) return true
+                        if (installedApp.packageName.contains(it.packageName)) return true
                     }
 
                     SelectionCriteria.MATCH -> {
-                        if (it.packageName == app.packageName) return true
+                        if (it.packageName == installedApp.packageName) return true
                     }
                 }
             }
@@ -51,17 +52,18 @@ class BillingProtector(private val context: Context) {
      * */
     fun getPirateAppsList(): List<PirateApp> {
         val foundThreats = mutableListOf<PirateApp>()
-        val appList = context.packageManager.getInstalledApplications(PackageManager.GET_META_DATA)
+        val installedApps = context.packageManager.getInstalledApplications(PackageManager.GET_META_DATA)
+        val pirateApps = createPirateAppsList()
 
-        for (app in appList) {
-            createPirateAppsList().map {
+        installedApps.forEach { installedApp ->
+            pirateApps.forEach {
                 when (it.criteria) {
                     SelectionCriteria.SLICE -> {
-                        if (it.packageName.contains(app.packageName)) foundThreats.add(it)
+                        if (installedApp.packageName.contains(it.packageName)) foundThreats.add(it)
                     }
 
                     SelectionCriteria.MATCH -> {
-                        if (it.packageName == app.packageName) foundThreats.add(it)
+                        if (it.packageName == installedApp.packageName) foundThreats.add(it)
                     }
                 }
             }

--- a/library/src/main/java/com/andreacioccarelli/billingprotector/utils/RootUtils.kt
+++ b/library/src/main/java/com/andreacioccarelli/billingprotector/utils/RootUtils.kt
@@ -10,6 +10,8 @@ import java.io.InputStreamReader
  */
 internal object RootUtils {
 
+    private const val INSPECTION_COMMAND = "which su"
+
     /**
      * Requests the root binary path by using unix which command, that
      * returns the path of a specified executable, in this case, su
@@ -23,10 +25,8 @@ internal object RootUtils {
      *          nothing is found in the host system
      * */
     internal fun extractPath(): String {
-        val inspectionCommand = "which su"
-
         return try {
-            val process = Runtime.getRuntime().exec(inspectionCommand)
+            val process = Runtime.getRuntime().exec(INSPECTION_COMMAND)
 
             val outputBuffer = StringBuffer()
             val bufferedReader = BufferedReader(InputStreamReader(process.inputStream))


### PR DESCRIPTION
Thanks for this! I've learning something new here. In return, I thought I'd share some fixes I had to do.

Shows my app not having root installed but having pirated apps installed
anyway. In the pirated apps list, it showed `com.android.vending.billing.InAppBillingService`
twice. This is because the `contains` slice check was incorrect.

Example: I had some app with package name as just `android` and another
with package name `com.android.vending` so check previously was if `com.android.vending.billing.InAppBillingService`
contained `android`. This should be reversed.